### PR TITLE
provide `main` and `module` fields for older bundlers

### DIFF
--- a/.changeset/proud-brooms-draw.md
+++ b/.changeset/proud-brooms-draw.md
@@ -1,0 +1,5 @@
+---
+"babel-dead-code-elimination": patch
+---
+
+Provide `main` and `module` fields in `package.json` for older bundlers

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Composable primitives for dead code elimination in Babel
 
 This package is **not a Babel plugin**, but rather a set of composable primitives to author your own Babel transforms and plugins.
 
+## Install
+
+```sh
+npm install babel-dead-code-elimination
+```
+
 ## deadCodeElimination
 
 Eliminates unused code from the Babel AST by repeatedly removing unreferenced identifiers.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "code",
     "elimination"
   ],
-  "repository": "pcattori/babel-dce-kit",
+  "repository": "pcattori/babel-dead-code-elimination",
   "author": "pcattori",
   "license": "MIT",
   "type": "module",
@@ -19,6 +19,8 @@
     },
     "./package.json": "./package.json"
   },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.cjs",
   "scripts": {
     "typecheck": "tsc",
     "build": "tsup",


### PR DESCRIPTION
for example, React Router uses rollup v2