### PR TITLE
Do not eliminate empty object/array pattern function parameters

### DIFF
--- a/.changeset/tiny-zebras-warn.md
+++ b/.changeset/tiny-zebras-warn.md
@@ -1,0 +1,7 @@
+---
+"babel-dead-code-elimination": patch
+---
+
+Do not eliminate empty object/array pattern function parameters
+
+Function parameters are not dead code

--- a/src/dead-code-elimination.test.ts
+++ b/src/dead-code-elimination.test.ts
@@ -234,6 +234,102 @@ describe("variable", () => {
       `)
     })
 
+    describe("within function param", () => {
+      test("within function declaration", async () => {
+        let source = dedent`
+          function f(a, {}) { return a; }
+          ref(f)
+        `
+        expect(await dce(source)).toMatchInlineSnapshot(`
+          "function f(a, {}) {
+            return a
+          }
+          ref(f)
+          "
+        `)
+      })
+
+      test("within function expression", async () => {
+        let source = dedent`
+          const f = function(a, {}) { return a }
+          ref(f)
+        `
+        expect(await dce(source)).toMatchInlineSnapshot(`
+          "const f = function (a, {}) {
+            return a
+          }
+          ref(f)
+          "
+        `)
+      })
+
+      test("within object method", async () => {
+        let source = dedent`
+          const a = {
+            f(a, {}) { return a }
+          }
+          ref(a.f)
+        `
+        expect(await dce(source)).toMatchInlineSnapshot(`
+          "const a = {
+            f(a, {}) {
+              return a
+            },
+          }
+          ref(a.f)
+          "
+        `)
+      })
+
+      test("within arrow function expression", async () => {
+        let source = dedent`
+          let f = (a, {}) => a
+          ref(f)
+        `
+        expect(await dce(source)).toMatchInlineSnapshot(`
+          "let f = (a, {}) => a
+          ref(f)
+          "
+        `)
+      })
+
+      test("within class method", async () => {
+        let source = dedent`
+          class A {
+            f(a, {}) { return a }
+          }
+          ref(A)
+        `
+        expect(await dce(source)).toMatchInlineSnapshot(`
+          "class A {
+            f(a, {}) {
+              return a
+            }
+          }
+          ref(A)
+          "
+        `)
+      })
+
+      test("within class private method", async () => {
+        let source = dedent`
+          class A {
+            #f(a, {}) { return a }
+          }
+          ref(A)
+        `
+        expect(await dce(source)).toMatchInlineSnapshot(`
+          "class A {
+            #f(a, {}) {
+              return a
+            }
+          }
+          ref(A)
+          "
+        `)
+      })
+    })
+
     test("unzips if all variables are unused", async () => {
       let source = dedent`
         let {

--- a/src/dead-code-elimination.ts
+++ b/src/dead-code-elimination.ts
@@ -96,8 +96,11 @@ export default function (
       ObjectPattern(path) {
         let isWithinDeclarator =
           path.find((p) => p.isVariableDeclarator()) !== null
+        let isFunctionParam =
+          path.parentPath.isFunction() &&
+          path.parentPath.node.params.includes(path.node)
         let isEmpty = path.node.properties.length === 0
-        if (isWithinDeclarator && isEmpty) {
+        if (isWithinDeclarator && !isFunctionParam && isEmpty) {
           Pattern.remove(path)
           removals++
         }
@@ -105,8 +108,11 @@ export default function (
       ArrayPattern(path) {
         let isWithinDeclarator =
           path.find((p) => p.isVariableDeclarator()) !== null
+        let isFunctionParam =
+          path.parentPath.isFunction() &&
+          path.parentPath.node.params.includes(path.node)
         let isEmpty = path.node.elements.every((e) => e === null)
-        if (isWithinDeclarator && isEmpty) {
+        if (isWithinDeclarator && !isFunctionParam && isEmpty) {
           Pattern.remove(path)
           removals++
         }


### PR DESCRIPTION
Either of the following code currently crashes the plugin:

```js
function f(a, {}) { return a; }
const f = function(a, {}) { return a }
const a = {
    f(a, {}) { return a }
}
let f = (a, {}) => a
class A {
    f(a, {}) { return a }
}
class A {
    #f(a, {}) { return a }
}
```

This is due to the parameters in the functions being empty object/array patterns. They should never be eliminated.

The code in the AST visitor in dead-code-elimination.ts was amended to check if a object/array pattern's parent path is a function using `isFunction()`.

`isFunction()` is true iff (https://github.com/babel/babel/blob/main/packages/babel-types/src/validators/generated/index.ts#L3022):

```ts
export function isFunction(
  node: t.Node | null | undefined,
  opts?: Opts<t.Function> | null,
): node is t.Function {
  if (!node) return false;

  switch (node.type) {
    case "FunctionDeclaration":
    case "FunctionExpression":
    case "ObjectMethod":
    case "ArrowFunctionExpression":
    case "ClassMethod":
    case "ClassPrivateMethod":
      break;
    default:
      return false;
  }

  return opts == null || shallowEqual(node, opts);
}
```